### PR TITLE
Doc: mention the importance of Pipeline.Close() in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ for r.Next() {
         log.Fatal(err)
     }
 }
+p.Close() // allow the underlying connection to be reused.
 ```
 
 Fun fact: authentication happens over a pipeline, so it doesn't incur a round-trip.


### PR DESCRIPTION
Hi @ammario,

Thank you for this inspiring implementation. I am also trying to add streaming read functionality to rueidis.

While benchmarking redjet and rueidis by myself, I found `Pipeline.Close()` could be crucial but missing from the README. 
So I tweaked the example and mentioned its importance as a comment in this PR.

